### PR TITLE
Avoid a divide-by-zero in the currentTime algorithm

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -531,7 +531,9 @@ as follows:
     return an unresolved time value if {{fill}} is <code>none</code> or
     <code>backwards</code>, or the [=effective time range=] otherwise.
 
-5.  Return the result of evaluating the following expression:
+5.  If {{startScrollOffset}} is equal to {{endScrollOffset}}, return an unresolved time value.
+
+6.  Return the result of evaluating the following expression:
 
     <blockquote>
       <code>(<var>current scroll offset</var> - {{startScrollOffset}}) / ({{endScrollOffset}} - {{startScrollOffset}}) &times; [=effective time range=]</code>


### PR DESCRIPTION
Previously if startScrollOffset == endScrollOffset then the final step
of the currentTime algorithm became:

(current scroll offset / 0) * effective time range

Since division by zero is undefined, insert a step to bail if this is
going to happen.

Note that since startScrollOffset and endScrollOffset can be calc()
values, we don't know until resolution whether they are equal, and they
may be equal in one call to currentTime and then not equal later.

Fixes #21