### PR TITLE
Remove 'auto' value for ScrollDirection

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -304,7 +304,6 @@ This content can't build the CSS only.
 
 <pre class="idl">
 enum ScrollDirection {
-  "auto",
   "block",
   "inline",
   "horizontal",
@@ -314,11 +313,6 @@ enum ScrollDirection {
 
 The {{ScrollDirection}} enumeration specifies a direction of scroll of a
 scrollable element.
-
-:   <code>auto</code>
-::  If only one direction is scrollable, selects that direction.
-    Otherwise selects the direction along the [=block axis=], conforming to
-    writing mode and directionality.
 
 :   <code>block</code>
 ::  Selects the direction along the [=block axis=], conforming to writing mode
@@ -341,16 +335,6 @@ directions allows web developers to animate both logical (e.g.
 margin-inline-start) and physical (e.g. transform) properties with good
 behavior under different directionalities and writing modes.
 
-<div class="issue">
-
-What about a value that means, "the longest scroll direction"? That would be
-more reliable than "auto" for the case where layout differences could mean that,
-although normally you only expect the block direction to be scrollable, on
-some devices you end up with a small scrollable range in the inline direction
-too.
-
-</div>
-
 ### The {{ScrollTimeline}} interface ### {#scrolltimeline-interface}
 
 <pre class="idl">
@@ -358,7 +342,7 @@ enum ScrollTimelineAutoKeyword { "auto" };
 
 dictionary ScrollTimelineOptions {
   Element scrollSource;
-  ScrollDirection orientation = "auto";
+  ScrollDirection orientation = "block";
   DOMString startScrollOffset = "auto";
   DOMString endScrollOffset = "auto";
   (double or ScrollTimelineAutoKeyword) timeRange = "auto";


### PR DESCRIPTION
As specced this value causes implementation difficulties around the
definition of 'scrollable' and the possibility of instability in the
resultant ScrollTimeline (see issues #15 and #16). For now we have
resolved to just remove it, with "block" becoming the default for a
ScrollTimeline.