### PR TITLE
Fix the definitions for fill forwards/backwards

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -460,26 +460,26 @@ not by wall-clock time, but by the progress of scrolling in a [=scroll container
 
     :   none
     ::  The timeline is inactive when the scroll offset is less than {{startScrollOffset}} 
-        or greater than {{endScrollOffset}}.
+        or greater than or equal to {{endScrollOffset}}.
 
     :   forwards
     ::  When the scroll offset is less than {{startScrollOffset}}, the
         timeline is inactive.
-        When the scroll offset is greater than {{endScrollOffset}}, the
-        timeline's [=current time=] is its
+        When the scroll offset is greater than or equal to the
+        {{endScrollOffset}}, the timeline's [=current time=] is its
         [=effective time range=].
 
     :   backwards
     ::  When the scroll offset is less than {{startScrollOffset}}, the
         timeline's [=current time=] is 0.
-        When the scroll offset is greater than {{endScrollOffset}}, the
-        timeline is inactive.
+        When the scroll offset is greater than or equal to the
+        {{endScrollOffset}}, the timeline is inactive.
 
     :   both
     ::  When the scroll offset is less than {{startScrollOffset}}, the
         timeline's [=current time=] is 0.
-        When the scroll offset is greater than {{endScrollOffset}}, the
-        timeline's [=current time=] is its
+        When the scroll offset is greater than or equal to the
+        {{endScrollOffset}}, the timeline's [=current time=] is its
         [=effective time range=].
 
     :   auto

--- a/Overview.bs
+++ b/Overview.bs
@@ -464,27 +464,27 @@ not by wall-clock time, but by the progress of scrolling in a [=scroll container
 
     :   forwards
     ::  When the scroll offset is less than {{startScrollOffset}}, the
-        timeline's [=current time=] is 0.
-        When the scroll offset is greater than {{endScrollOffset}}, the
         timeline is inactive.
+        When the scroll offset is greater than {{endScrollOffset}}, the
+        timeline's [=current time=] is its
+        [=effective time range=].
 
     :   backwards
     ::  When the scroll offset is less than {{startScrollOffset}}, the
-        timeline is inactive.
+        timeline's [=current time=] is 0.
         When the scroll offset is greater than {{endScrollOffset}}, the
-        timeline's [=current time=] is its 
-        [=effective time range=].
+        timeline is inactive.
 
     :   both
     ::  When the scroll offset is less than {{startScrollOffset}}, the
         timeline's [=current time=] is 0.
         When the scroll offset is greater than {{endScrollOffset}}, the
-        timeline's [=current time=] is its 
+        timeline's [=current time=] is its
         [=effective time range=].
 
     :   auto
     ::  Behaves the same as <code>both</code>.
-        
+
 </div>
 
 ### The effective time range of a {{ScrollTimeline}} ### {#efffective-time-range-algorithm}


### PR DESCRIPTION
Although correct in the currentTime algorithm, the definitions were
inverted. Swap them with each other so that the definition matches what
they actually mean.